### PR TITLE
動的な日記投稿フォームの作成

### DIFF
--- a/app/assets/javascripts/tweet.js
+++ b/app/assets/javascripts/tweet.js
@@ -11,8 +11,7 @@ function hilight_checked_item(){
     $(this).addClass("checked")
 
     var checked_phrase = $(this).text()
-    var phrase_items_box = $(this).closest(".phrase_items")
-    var phrase_type = phrase_items_box.attr("id")
+    var phrase_type = $(this).closest(".phrase_items").attr("id")
     $(".phrase_type_btn#"+phrase_type).text(checked_phrase)
   }))
 }

--- a/app/assets/javascripts/tweet.js
+++ b/app/assets/javascripts/tweet.js
@@ -1,0 +1,9 @@
+$(document).ready(function() { hilight_checked_item() });
+
+function hilight_checked_item(){
+  $(".phrase_item").on("click", (function(){
+    $(this).siblings().removeClass("checked")
+    $(this).addClass("checked")
+  }))
+}
+//投稿フォームで、選択された項目を目立たせるためのclassを追加するため

--- a/app/assets/javascripts/tweet.js
+++ b/app/assets/javascripts/tweet.js
@@ -4,13 +4,20 @@ $(document).ready(function() {
 });
 
 //投稿フォーム用javascript
+
 function hilight_checked_item(){
   $(".phrase_item").on("click", (function(){
     $(this).siblings().removeClass("checked")
     $(this).addClass("checked")
+
+    var checked_phrase = $(this).text()
+    var phrase_items_box = $(this).closest(".phrase_items")
+    var phrase_type = phrase_items_box.attr("id")
+    $(".phrase_type_btn#"+phrase_type).text(checked_phrase)
   }))
 }
 //クリックされた選択項目を目立たせるためのclassを追加するため
+//クリックされた選択項目をフォーム上部に表示するため
 
 function render_phrase_items(){
   $(".phrase_type_btn").on("click", (function(){

--- a/app/assets/javascripts/tweet.js
+++ b/app/assets/javascripts/tweet.js
@@ -1,9 +1,22 @@
-$(document).ready(function() { hilight_checked_item() });
+$(document).ready(function() { 
+	hilight_checked_item(), 
+	render_phrase_items()
+});
 
+//投稿フォーム用javascript
 function hilight_checked_item(){
   $(".phrase_item").on("click", (function(){
     $(this).siblings().removeClass("checked")
     $(this).addClass("checked")
   }))
 }
-//投稿フォームで、選択された項目を目立たせるためのclassを追加するため
+//クリックされた選択項目を目立たせるためのclassを追加するため
+
+function render_phrase_items(){
+  $(".phrase_type_btn").on("click", (function(){
+       var phrase_type = $(this).attr("id")
+       $(".phrase_items").hide()
+       $(this).siblings("#" + phrase_type).show()
+  }))
+}
+//aタグをクリックすると、タグに応じた文章の選択項目を表示するため

--- a/app/assets/stylesheets/tweets.scss
+++ b/app/assets/stylesheets/tweets.scss
@@ -1,15 +1,7 @@
-.phrase_form {
-  label {
-	&.selected {
-	  font-size: 30px;
-    }
-  }
-  select {
-  	display: none;
-
-  	&.selected {
-	  width: 100px;
-	  height: 30px;
+.tweet_items {
+  .phrase_items {
+    input {
+      display: none;
     }
   }
 }

--- a/app/assets/stylesheets/tweets.scss
+++ b/app/assets/stylesheets/tweets.scss
@@ -10,5 +10,9 @@ $accent: #57C3E9;
     .phrase_input {
       display: none;
     }
+
+    &.checked {
+      font-weight: bold;
+    }
   }
 }

--- a/app/assets/stylesheets/tweets.scss
+++ b/app/assets/stylesheets/tweets.scss
@@ -1,6 +1,13 @@
-.tweet_items {
-  .phrase_items {
-    input {
+$accent: #57C3E9;
+
+.phrase_forms {
+  .phrase_item {
+    display: inline;
+    &:hover {
+      border-color: lighten($accent, 15%);
+      color: lighten($accent, 15%);
+    }
+    .phrase_input {
       display: none;
     }
   }

--- a/app/assets/stylesheets/tweets.scss
+++ b/app/assets/stylesheets/tweets.scss
@@ -1,18 +1,23 @@
 $accent: #57C3E9;
 
 .phrase_forms {
-  .phrase_item {
-    display: inline;
-    &:hover {
-      border-color: lighten($accent, 15%);
-      color: lighten($accent, 15%);
-    }
-    .phrase_input {
-      display: none;
-    }
+  .phrase_items {
+    .phrase_item {
+      display: inline;
+      &:hover {
+        border-color: lighten($accent, 15%);
+        color: lighten($accent, 15%);
+      }
+      .phrase_input {
+        display: none;
+      }
 
-    &.checked {
-      font-weight: bold;
+      &.checked {
+        font-weight: bold;
+      }
+    }
+    &:not(#subject) {
+      display: none;
     }
   }
 }

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -8,15 +8,13 @@ class TweetsController < ApplicationController
 
   def new
     @tweet = Tweet.new
+    Phrase::Phrase_types_count.times {@tweet.tweet_phrases.build}
     @phrases = Phrase.all
   end
 
   def create
-    tweet = current_user.tweets.create(image: tweet_params[:image])
-    tweet.tweet_phrases.create(phrase_id: tweet_params[:tweet_phrase][:subject_id])
-    tweet.tweet_phrases.create(phrase_id: tweet_params[:tweet_phrase][:object_id])
-    tweet.tweet_phrases.create(phrase_id: tweet_params[:tweet_phrase][:verb_id])
-    tweet.tweet_phrases.create(phrase_id: tweet_params[:tweet_phrase][:impression_id])
+    binding.pry
+    tweet = current_user.tweets.create(tweet_params)
   end
 
   def destroy
@@ -44,7 +42,7 @@ class TweetsController < ApplicationController
 
   private
   def tweet_params
-     params.require(:tweet).permit(:image, tweet_phrase: [:subject_id, :object_id, :verb_id, :impression_id])
+     params.require(:tweet).permit(:image, tweet_phrases_attributes: [:subject_id])
   end
 
   def move_to_index

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -8,7 +8,7 @@ class TweetsController < ApplicationController
 
   def new
     @tweet = Tweet.new
-    Phrase.phrase_types.count.times {@tweet.tweet_phrases.build}
+    @tweet.tweet_phrases.build
     @phrases = Phrase.all
   end
 

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -8,12 +8,11 @@ class TweetsController < ApplicationController
 
   def new
     @tweet = Tweet.new
-    Phrase::Phrase_types_count.times {@tweet.tweet_phrases.build}
+    Phrase.phrase_types.count.times {@tweet.tweet_phrases.build}
     @phrases = Phrase.all
   end
 
   def create
-    binding.pry
     tweet = current_user.tweets.create(tweet_params)
   end
 
@@ -42,7 +41,7 @@ class TweetsController < ApplicationController
 
   private
   def tweet_params
-     params.require(:tweet).permit(:image, tweet_phrases_attributes: [:subject_id])
+     params.require(:tweet).permit(:image, tweet_phrases_attributes: [:phrase_id])
   end
 
   def move_to_index

--- a/app/models/phrase.rb
+++ b/app/models/phrase.rb
@@ -4,6 +4,4 @@ class Phrase < ActiveRecord::Base
 
   accepts_nested_attributes_for :tweets
   enum phrase_type: [:subject, :object, :verb, :impression]
-
-  Phrase_types_count = Phrase.phrase_types.count
 end

--- a/app/models/phrase.rb
+++ b/app/models/phrase.rb
@@ -4,4 +4,6 @@ class Phrase < ActiveRecord::Base
 
   accepts_nested_attributes_for :tweets
   enum phrase_type: [:subject, :object, :verb, :impression]
+
+  Phrase_types_count = Phrase.phrase_types.count
 end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -4,5 +4,5 @@ class Tweet < ActiveRecord::Base
   has_many :tweet_phrases
   has_many :comments           #commentsテーブルとのアソシエーション
 
-  accepts_nested_attributes_for :phrases
+  accepts_nested_attributes_for :tweet_phrases
 end

--- a/app/views/tweets/new.html.erb
+++ b/app/views/tweets/new.html.erb
@@ -9,8 +9,8 @@
         <div class= "phrase_forms">
           <% Phrase.phrase_types.each_pair do |phrase_type, phrase_type_id|%>
             <%= f.fields_for :tweet_phrases do |tweet_phrase| %>
-              <%= content_tag :a, phrase_type, class: "btn phrase_type_btn"%>
-              <div class="phrase_items" id= "<%= phrase_type %>" >
+              <%= content_tag :a, phrase_type, class: "btn phrase_type_btn", id: "#{phrase_type}"%>
+              <div class="phrase_items" id= "<%= phrase_type %>"] >
                 <% @phrases.where(phrase_type: phrase_type_id).each do |item| %>
                   <div class= "phrase_item">
                     <%= tweet_phrase.label "phrase_id_#{item.id}" do %>

--- a/app/views/tweets/new.html.erb
+++ b/app/views/tweets/new.html.erb
@@ -7,10 +7,12 @@
         </h3>
         <%= f.text_field :image, placeholder: "あたらしく　かいた　絵(のURL)", autofocus: "true" %>
         <div class= "phrase_forms">
+          <% Phrase.phrase_types.each_key do |phrase_type|%>
+            <%= content_tag :a, phrase_type, class: "btn phrase_type_btn", id: "#{phrase_type}", remote: true%>
+          <% end %>
           <% Phrase.phrase_types.each_pair do |phrase_type, phrase_type_id|%>
             <%= f.fields_for :tweet_phrases do |tweet_phrase| %>
-              <%= content_tag :a, phrase_type, class: "btn phrase_type_btn", id: "#{phrase_type}"%>
-              <div class="phrase_items" id= "<%= phrase_type %>"] >
+              <div class="phrase_items" id= "<%= phrase_type %>" >
                 <% @phrases.where(phrase_type: phrase_type_id).each do |item| %>
                   <div class= "phrase_item">
                     <%= tweet_phrase.label "phrase_id_#{item.id}" do %>

--- a/app/views/tweets/new.html.erb
+++ b/app/views/tweets/new.html.erb
@@ -16,45 +16,14 @@
 
       <div class="tweet_items">
         <div class="phrase_items">
-          <%= f.fields_for :tweet_phrase do |tweet_phrase| %>
-            <% @phrases.subject.each do |item| %>
-              <%= tweet_phrase.label "phrase_id_value#{item.id}" do %>
-                <%= tweet_phrase.radio_button :phrase_id, value: item.id%>
-                <%= item.text %>
-              <% end %>
-            <% end %>
-          <% end %>
-        </div>
-
-        <div class="phrase_items">
-          <%= f.fields_for :tweet_phrase do |tweet_phrase| %>
-            <% @phrases.object.each do |item| %>
-              <%= tweet_phrase.label "phrase_id_value#{item.id}" do %>
-                <%= tweet_phrase.radio_button :phrase_id, value: item.id%>
-                <%= item.text %>
-              <% end %>
-            <% end %>
-          <% end %>
-        </div>
-
-        <div class="phrase_items">
-          <%= f.fields_for :tweet_phrase do |tweet_phrase| %>
-            <% @phrases.verb.each do |item| %>
-              <%= tweet_phrase.label "phrase_id_value#{item.id}" do %>
-                <%= tweet_phrase.radio_button :phrase_id, value: item.id%>
-                <%= item.text %>
-              <% end %>
-            <% end %>
-          <% end %>
-        </div>
-
-        <div class="phrase_items">
-          <%= f.fields_for :tweet_phrase do |tweet_phrase| %>
-            <% @phrases.impression.each do |item| %>
-              <%= tweet_phrase.label "phrase_id_value#{item.id}" do %>
-                <%= tweet_phrase.radio_button :phrase_id, value: item.id%>
-                <%= item.text %>
-              <% end %>
+          <%= f.fields_for :tweet_phrases do |tweet_phrase| %>
+            <% @phrases.each do |item| %>
+              <div id= <%= item.phrase_type %> >
+                <%= tweet_phrase.label "phrase_id_#{item.id}" do %>
+                  <%= tweet_phrase.radio_button :phrase_id, item.id%>
+                  <%= item.text %>
+                <% end %>
+              </div>
             <% end %>
           <% end %>
         </div>

--- a/app/views/tweets/new.html.erb
+++ b/app/views/tweets/new.html.erb
@@ -10,7 +10,7 @@
           <% Phrase.phrase_types.each_pair do |phrase_type, phrase_type_id|%>
             <%= f.fields_for :tweet_phrases do |tweet_phrase| %>
               <%= content_tag :a, phrase_type, class: "btn phrase_type_btn"%>
-              <div class="phrase_items">
+              <div class="phrase_items" id= "<%= phrase_type %>" >
                 <% @phrases.where(phrase_type: phrase_type_id).each do |item| %>
                   <div class= "phrase_item">
                     <%= tweet_phrase.label "phrase_id_#{item.id}" do %>

--- a/app/views/tweets/new.html.erb
+++ b/app/views/tweets/new.html.erb
@@ -6,27 +6,21 @@
           あたらしい 絵にっきを かく
         </h3>
         <%= f.text_field :image, placeholder: "あたらしく　かいた　絵(のURL)", autofocus: "true" %>
-        <div class="phrase_forms">
-          <%= f.label "誰が", id: "tweet_tweet_phrase_subject_id"%>
-          <%= f.label "何を", id: "tweet_tweet_phrase_object_id"%>
-          <%= f.label "どうした？", id: "tweet_tweet_phrase_verb_id"%>
-          <%= f.label "どうだった？", id: "tweet_tweet_phrase_impression_id"%>
-        </div>
-      </div>
-
-      <div class="tweet_items">
-        <div class="phrase_items">
+        <% Phrase.phrase_types.each_pair do |phrase_type, phrase_type_id|%>
           <%= f.fields_for :tweet_phrases do |tweet_phrase| %>
-            <% @phrases.each do |item| %>
-              <div id= <%= item.phrase_type %> >
-                <%= tweet_phrase.label "phrase_id_#{item.id}" do %>
-                  <%= tweet_phrase.radio_button :phrase_id, item.id%>
-                  <%= item.text %>
-                <% end %>
-              </div>
-            <% end %>
+            <%= content_tag :a, phrase_type, class: "btn phrase_type_btn"%>
+            <div class="phrase_items">
+              <% @phrases.where(phrase_type: phrase_type_id).each do |item| %>
+                <div id= <%= item.phrase_type %> >
+                  <%= tweet_phrase.label "phrase_id_#{item.id}" do %>
+                    <%= tweet_phrase.radio_button :phrase_id, item.id%>
+                    <%= item.text %>
+                  <% end %>
+                </div>
+              <% end %>
+            </div>
           <% end %>
-        </div>
+        <% end %>
       </div>
       <%= f.submit value: "お友だちにみせよう" %>
     <% end %>

--- a/app/views/tweets/new.html.erb
+++ b/app/views/tweets/new.html.erb
@@ -1,38 +1,66 @@
 <div class="contents row">
   <div class="container">
     <%= form_for(@tweet) do |f|%>
-      <h3>
-        あたらしい 絵にっきを かく
-      </h3>
-
-      <%= f.text_field :image, placeholder: "あたらしく　かいた　絵(のURL)", autofocus: "true" %>
-      <div class="phrase_forms">
-        <%= f.fields_for :tweet_phrase do |tweet_phrase| %>
-          <%= f.label "誰が", id: "tweet_tweet_phrase_subject_id", class: "selected"%>
-          <div class: "phrase_form_items selected">
-            <%= tweet_phrase.select :subject_id , @phrases.subject.map{|p| [p.text, p.id]} %>
-          </div>
-        <% end %>
-
-        <%= f.fields_for :tweet_phrase do |tweet_phrase| %>
+      <div class="tweet_forms">
+        <h3>
+          あたらしい 絵にっきを かく
+        </h3>
+        <%= f.text_field :image, placeholder: "あたらしく　かいた　絵(のURL)", autofocus: "true" %>
+        <div class="phrase_forms">
+          <%= f.label "誰が", id: "tweet_tweet_phrase_subject_id"%>
           <%= f.label "何を", id: "tweet_tweet_phrase_object_id"%>
-          <div class: "phrase_form_items">
-            <%= tweet_phrase.select :object_id , @phrases.object.map{|p| [p.text, p.id]} %>
-          </div>
-        <% end %>
+          <%= f.label "どうした？", id: "tweet_tweet_phrase_verb_id"%>
+          <%= f.label "どうだった？", id: "tweet_tweet_phrase_impression_id"%>
+        </div>
+      </div>
 
-        <%= f.fields_for :tweet_phrase do |tweet_phrase| %>
-          <%= f.label "どうした？", class: "verb"%>
-          <%= tweet_phrase.select :verb_id , @phrases.verb.map{|p| [p.text, p.id]} %>
-        <% end %>
+      <div class="tweet_items">
+        <div class="phrase_items">
+          <%= f.fields_for :tweet_phrase do |tweet_phrase| %>
+            <% @phrases.subject.each do |item| %>
+              <%= tweet_phrase.label "phrase_id_value#{item.id}" do %>
+                <%= tweet_phrase.radio_button :phrase_id, value: item.id%>
+                <%= item.text %>
+              <% end %>
+            <% end %>
+          <% end %>
+        </div>
 
-        <%= f.fields_for :tweet_phrase do |tweet_phrase| %>
-          <%= f.label "どうだった？", class: "impression"%>
-          <%= tweet_phrase.select :impression_id , @phrases.impression.map{|p| [p.text, p.id]} %>
-        <% end %>
+        <div class="phrase_items">
+          <%= f.fields_for :tweet_phrase do |tweet_phrase| %>
+            <% @phrases.object.each do |item| %>
+              <%= tweet_phrase.label "phrase_id_value#{item.id}" do %>
+                <%= tweet_phrase.radio_button :phrase_id, value: item.id%>
+                <%= item.text %>
+              <% end %>
+            <% end %>
+          <% end %>
+        </div>
 
+        <div class="phrase_items">
+          <%= f.fields_for :tweet_phrase do |tweet_phrase| %>
+            <% @phrases.verb.each do |item| %>
+              <%= tweet_phrase.label "phrase_id_value#{item.id}" do %>
+                <%= tweet_phrase.radio_button :phrase_id, value: item.id%>
+                <%= item.text %>
+              <% end %>
+            <% end %>
+          <% end %>
+        </div>
+
+        <div class="phrase_items">
+          <%= f.fields_for :tweet_phrase do |tweet_phrase| %>
+            <% @phrases.impression.each do |item| %>
+              <%= tweet_phrase.label "phrase_id_value#{item.id}" do %>
+                <%= tweet_phrase.radio_button :phrase_id, value: item.id%>
+                <%= item.text %>
+              <% end %>
+            <% end %>
+          <% end %>
+        </div>
       </div>
       <%= f.submit value: "お友だちにみせよう" %>
     <% end %>
   </div>
 </div>
+

--- a/app/views/tweets/new.html.erb
+++ b/app/views/tweets/new.html.erb
@@ -6,21 +6,23 @@
           あたらしい 絵にっきを かく
         </h3>
         <%= f.text_field :image, placeholder: "あたらしく　かいた　絵(のURL)", autofocus: "true" %>
-        <% Phrase.phrase_types.each_pair do |phrase_type, phrase_type_id|%>
-          <%= f.fields_for :tweet_phrases do |tweet_phrase| %>
-            <%= content_tag :a, phrase_type, class: "btn phrase_type_btn"%>
-            <div class="phrase_items">
-              <% @phrases.where(phrase_type: phrase_type_id).each do |item| %>
-                <div id= <%= item.phrase_type %> >
-                  <%= tweet_phrase.label "phrase_id_#{item.id}" do %>
-                    <%= tweet_phrase.radio_button :phrase_id, item.id%>
-                    <%= item.text %>
-                  <% end %>
-                </div>
-              <% end %>
-            </div>
+        <div class= "phrase_forms">
+          <% Phrase.phrase_types.each_pair do |phrase_type, phrase_type_id|%>
+            <%= f.fields_for :tweet_phrases do |tweet_phrase| %>
+              <%= content_tag :a, phrase_type, class: "btn phrase_type_btn"%>
+              <div class="phrase_items">
+                <% @phrases.where(phrase_type: phrase_type_id).each do |item| %>
+                  <div class= "phrase_item">
+                    <%= tweet_phrase.label "phrase_id_#{item.id}" do %>
+                      <%= tweet_phrase.radio_button :phrase_id, item.id, class: "phrase_input"%>
+                      <%= item.text %>
+                    <% end %>
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
           <% end %>
-        <% end %>
+        </div>
       </div>
       <%= f.submit value: "お友だちにみせよう" %>
     <% end %>


### PR DESCRIPTION
# WHY
- ユーザが直感的に日記文章を作成することができるようにするため

# WHAT
- ```tweets/new.html.erb``` の完成
  - 各選択項目は一旦下方向に連なる

- ```stylesheets/tweet.scss```の完成
  - subject_formsに```id: "selected"```を当てる
    - 上記のborderは他より太く
    - subject_itemsのみ表示
    - ほかは```display: "none"```

 -  ```tweet.coffee```の完成
   - xx_formsがクリックされたら、xx_items表示
   - xx_itemsがクリックされたら、xx_formsの文字変更

## ScreenShot
[![Image from Gyazo](https://i.gyazo.com/4f015f66cd32f572d85dc274b98ab1af.gif)](https://gyazo.com/4f015f66cd32f572d85dc274b98ab1af)