### PR TITLE
asset compileの設定変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = true
+  config.assets.compile = false
 
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.


### PR DESCRIPTION
herokuデプロイ時に脆弱性ありとのエラーがでたため
```
 !     A security vulnerability has been detected in your application.
 !     To protect your application you must take action. Your application
 !     is currently exposing its credentials via an easy to exploit directory
 !     traversal.
 !     
 !     To protect your application you must either upgrade to Sprockets version "2.12.5"
 !     or disable dynamic compilation at runtime by setting:
```