### PR TITLE
[WIP]リアクション関連機能の修正・追加

### DIFF
--- a/app/views/tweets/_tweet_comment.html.erb
+++ b/app/views/tweets/_tweet_comment.html.erb
@@ -1,0 +1,11 @@
+<div class="contents row">
+  <div class="container"> 
+    <!-- ここからフォーム -->
+    <% if current_user %>
+      <%= form_tag("/tweets/#{@tweet.id}/comments", method: :post) do %>
+        <textarea name="text" placeholder="コメントする" rows="2" cols="30"></textarea>
+        <input type="submit" value="SENT">
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/tweets/show.html.erb
+++ b/app/views/tweets/show.html.erb
@@ -1,3 +1,4 @@
 <div class="contents row" >
   <%= render @tweet %>
+  <%= render partial: "tweet_comment", locals: {comment: @comments}%>
 </div>


### PR DESCRIPTION
# WHY
- 日記に対する他者からの反応は、ユーザの日記投稿意欲を向上させるはず
- 日記投稿に対して、他のユーザが気軽にリアクション行動をとることができるようにするため

# WHAT
- いいね機能の修正
  - [ ] 2回ずつリクエストが送信されるエラー解決
  - [ ] 2番目のツイートに対するいいねが、1番目のツイートに加算されるエラー解決
  - [x] `_like.html.erb`を`_tweet.html.erb`から呼ぶ
- コメント機能のビュー追加
  - [x] コメントフォーム作成（部分テンプレート）
  - [ ] コメントビュー作成（部分テンプレート）
  - [ ] 上記を`_tweet.html.erb`に挿入
- `_tweet.html.erb` にリアクションビューの作成
  - [ ] comment_countを表示する
  - [ ] like_countを表示する